### PR TITLE
Add support for faking errors for throwing functions

### DIFF
--- a/Mokka/Mokka.xcodeproj/project.pbxproj
+++ b/Mokka/Mokka.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		214134AE22A1712F00CE8C6B /* FunctionMockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214134AD22A1712F00CE8C6B /* FunctionMockTests.swift */; };
 		2146A37322A4FCE3003BC36C /* PropertyMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2146A37222A4FCE3003BC36C /* PropertyMock.swift */; };
 		2146A37722A50457003BC36C /* PropertyMockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2146A37522A50403003BC36C /* PropertyMockTests.swift */; };
+		21E44C4E22D5FD10006CF49C /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E44C4D22D5FD10006CF49C /* TestError.swift */; };
 		21E7DAA022A1B72B00E0CA91 /* ReturningFunctionMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E7DA9F22A1B72B00E0CA91 /* ReturningFunctionMock.swift */; };
 		21E7DAA422A1C53400E0CA91 /* ReturningFunctionMockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E7DAA322A1C53400E0CA91 /* ReturningFunctionMockTests.swift */; };
 /* End PBXBuildFile section */
@@ -37,6 +38,7 @@
 		214134AD22A1712F00CE8C6B /* FunctionMockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionMockTests.swift; sourceTree = "<group>"; };
 		2146A37222A4FCE3003BC36C /* PropertyMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyMock.swift; sourceTree = "<group>"; };
 		2146A37522A50403003BC36C /* PropertyMockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyMockTests.swift; sourceTree = "<group>"; };
+		21E44C4D22D5FD10006CF49C /* TestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
 		21E7DA9F22A1B72B00E0CA91 /* ReturningFunctionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReturningFunctionMock.swift; sourceTree = "<group>"; };
 		21E7DAA322A1C53400E0CA91 /* ReturningFunctionMockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReturningFunctionMockTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -92,6 +94,7 @@
 		2141349522A164B600CE8C6B /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				21E44C4C22D5FCE9006CF49C /* Fixtures */,
 				214134AC22A1711A00CE8C6B /* FunctionMock */,
 				2146A37422A503EE003BC36C /* PropertyMock */,
 				2141349822A164B600CE8C6B /* Info.plist */,
@@ -131,6 +134,14 @@
 				2146A37522A50403003BC36C /* PropertyMockTests.swift */,
 			);
 			path = PropertyMock;
+			sourceTree = "<group>";
+		};
+		21E44C4C22D5FCE9006CF49C /* Fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				21E44C4D22D5FD10006CF49C /* TestError.swift */,
+			);
+			path = Fixtures;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -241,6 +252,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				21E44C4E22D5FD10006CF49C /* TestError.swift in Sources */,
 				2146A37322A4FCE3003BC36C /* PropertyMock.swift in Sources */,
 				21E7DAA022A1B72B00E0CA91 /* ReturningFunctionMock.swift in Sources */,
 				214134A822A16CDF00CE8C6B /* FunctionMock.swift in Sources */,

--- a/Mokka/Sources/FunctionMock/FunctionMock.swift
+++ b/Mokka/Sources/FunctionMock/FunctionMock.swift
@@ -64,7 +64,7 @@ public class FunctionMock<Args> {
     public var argument: Args? { return arguments }    // syntactic alternative for single-arg methods
 
     private var stubBlock: ((Args) -> Void)?
-    private var error: Error?
+    internal var error: Error?
     
     /// Creates a new instance of a function mock with the specified name.
     ///

--- a/Mokka/Sources/FunctionMock/ReturningFunctionMock.swift
+++ b/Mokka/Sources/FunctionMock/ReturningFunctionMock.swift
@@ -62,7 +62,7 @@ public class ReturningFunctionMock<Args, ReturnValue>: FunctionMock<Args> {
     /// - returns: The return value configured via `returns(...)`.
     public func recordCallAndReturn(_ args: Args) -> ReturnValue {
         recordCall(args)
-        return getReturnValue(args: args)
+        return stubbedReturnValue(for: args)
     }
     
     /// Record a call of the mocked function and potentially throw an error, if configured.
@@ -77,7 +77,7 @@ public class ReturningFunctionMock<Args, ReturnValue>: FunctionMock<Args> {
         if let error = error {
             throw error
         } else {
-            return getReturnValue(args: args)
+            return stubbedReturnValue(for: args)
         }
     }
 
@@ -125,7 +125,7 @@ public class ReturningFunctionMock<Args, ReturnValue>: FunctionMock<Args> {
     // MARK: - Private
     
     /// Get the stubbed return value for the specified arguments.
-    private func getReturnValue(args: Args) -> ReturnValue {
+    private func stubbedReturnValue(for args: Args) -> ReturnValue {
         guard let stub = stubs.first(where: { $0.shouldHandle(args) }) else {
             if let returnValue = defaultReturnValue {
                 return returnValue

--- a/Mokka/Sources/FunctionMock/ReturningFunctionMock.swift
+++ b/Mokka/Sources/FunctionMock/ReturningFunctionMock.swift
@@ -59,19 +59,28 @@ public class ReturningFunctionMock<Args, ReturnValue>: FunctionMock<Args> {
     ///
     /// - parameters:
     ///     - args: The arguments that the mocked function has been called with.
+    /// - returns: The return value configured via `returns(...)`.
     public func recordCallAndReturn(_ args: Args) -> ReturnValue {
         recordCall(args)
-        
-        // stub return value
-        guard let stub = stubs.first(where: { $0.shouldHandle(args) }) else {
-            if let returnValue = defaultReturnValue {
-                return returnValue
-            }
-            preconditionFailure("No return value for \(name ?? "function")")
-        }
-        
-        return stub.handle(args)
+        return getReturnValue(args: args)
     }
+    
+    /// Record a call of the mocked function and potentially throw an error, if configured.
+    ///
+    /// - parameters:
+    ///     - args: The arguments that the mocked function has been called with.
+    /// - returns: The return value configured via `returns(...)`.
+    /// - throws: The error that has been configured via `throws(_:)`, if any.
+    public func recordCallAndReturnOrThrow(_ args: Args) throws -> ReturnValue {
+        recordCall(args)
+
+        if let error = error {
+            throw error
+        } else {
+            return getReturnValue(args: args)
+        }
+    }
+
     
     // MARK: - Stubbing
     
@@ -111,6 +120,20 @@ public class ReturningFunctionMock<Args, ReturnValue>: FunctionMock<Args> {
     public func returns(_ handler: @escaping (_ args: Args) -> ReturnValue, when condition: ((Args) -> Bool)? = nil) {
         let stub = FunctionStub<Args, ReturnValue>(handler: handler, condition: condition)
         stubs.append(stub)
+    }
+    
+    // MARK: - Private
+    
+    /// Get the stubbed return value for the specified arguments.
+    private func getReturnValue(args: Args) -> ReturnValue {
+        guard let stub = stubs.first(where: { $0.shouldHandle(args) }) else {
+            if let returnValue = defaultReturnValue {
+                return returnValue
+            }
+            preconditionFailure("No return value for \(name ?? "function")")
+        }
+        
+        return stub.handle(args)
     }
     
     // MARK: - FunctionStub

--- a/Mokka/Tests/Fixtures/TestError.swift
+++ b/Mokka/Tests/Fixtures/TestError.swift
@@ -1,0 +1,16 @@
+//
+//  TestError.swift
+//  Mokka
+//
+//  Created by Daniel Rinser on 10.07.2019.
+//  Copyright © 2019 Daniel Rinser. All rights reserved.
+//
+
+import Foundation
+
+enum TestError: Error {
+    case errorOne
+    case errorTwo
+}
+
+extension TestError: Equatable {}

--- a/Mokka/Tests/FunctionMock/FunctionMockTests.swift
+++ b/Mokka/Tests/FunctionMock/FunctionMockTests.swift
@@ -127,6 +127,31 @@ class FunctionMockTests: XCTestCase {
         waitForExpectations(timeout: 0.0, handler: nil)
     }
     
+    // MARK: Throwing
+    
+    func testDoesNotThrowErrorIfNotExplicitlyConfigured() {
+        XCTAssertNoThrow(try sut.recordCallAndThrow("foo"))
+    }
+    
+    func testThrowsErrorAfterSettingError() {
+        sut.throws(TestError.errorOne)
+        XCTAssertThrowsError(try sut.recordCallAndThrow("foo")) { error in
+            XCTAssert(error is TestError, "Unexpected error type thrown")
+            XCTAssertEqual(error as! TestError, TestError.errorOne)
+        }
+    }
+
+    func testRecordCallAndThrowRecordsCalls() {
+        XCTAssertNoThrow(try sut.recordCallAndThrow("foo"))
+        XCTAssertNoThrow(try sut.recordCallAndThrow("bar"))
+        XCTAssertEqual(sut.callCount, 2)
+    }
+
+    func testRecordCallAndThrowCapturesArguments() {
+        XCTAssertNoThrow(try sut.recordCallAndThrow("foo"))
+        XCTAssertEqual(sut.argument, "foo")
+    }
+    
     // MARK: Reset
     
     func testCallCountIsZeroAfterReset() {
@@ -153,11 +178,23 @@ class FunctionMockTests: XCTestCase {
         XCTAssertNil(sut.argument)
     }
     
+    func testResetSetsErrorToNil() {
+        sut.throws(TestError.errorOne)
+        sut.reset()
+        XCTAssertNoThrow(try sut.recordCallAndThrow("foo"))
+    }
+    
     // MARK: Misc
     
     func testNoArgumentRecordCallOverloadRecordsCall() {
         let sut = FunctionMock<Void>(name: "test()")
         sut.recordCall()
+        XCTAssertEqual(sut.callCount, 1)
+    }
+
+    func testNoArgumentRecordCallAndThrowOverloadRecordsCall() {
+        let sut = FunctionMock<Void>(name: "test()")
+        XCTAssertNoThrow(try sut.recordCallAndThrow())
         XCTAssertEqual(sut.callCount, 1)
     }
 }

--- a/Mokka/Tests/FunctionMock/ReturningFunctionMockTests.swift
+++ b/Mokka/Tests/FunctionMock/ReturningFunctionMockTests.swift
@@ -186,25 +186,29 @@ class ReturningFunctionMockTests: XCTestCase {
     // MARK: Reset
     
     func testCallCountIsZeroAfterReset() {
-        sut.recordCall("foo")
+        sut.defaultReturnValue = 0
+        _ = sut.recordCallAndReturn("foo")
         sut.reset()
         XCTAssertEqual(sut.callCount, 0)
     }
     
     func testCalledReturnsFalseAfterReset() {
-        sut.recordCall("foo")
+        sut.defaultReturnValue = 0
+        _ = sut.recordCallAndReturn("foo")
         sut.reset()
         XCTAssertEqual(sut.called, false)
     }
     
     func testCalledOnceReturnsFalseAfterReset() {
-        sut.recordCall("foo")
+        sut.defaultReturnValue = 0
+        _ = sut.recordCallAndReturn("foo")
         sut.reset()
         XCTAssertEqual(sut.calledOnce, false)
     }
     
     func testResetSetsArgumentToNil() {
-        sut.recordCall("foo")
+        sut.defaultReturnValue = 0
+        _ = sut.recordCallAndReturn("foo")
         sut.reset()
         XCTAssertNil(sut.argument)
     }
@@ -232,6 +236,7 @@ class ReturningFunctionMockTests: XCTestCase {
     func testResetSetsErrorToNil() {
         sut.throws(TestError.errorOne)
         sut.reset()
+        sut.defaultReturnValue = 0
         XCTAssertNoThrow(try sut.recordCallAndReturnOrThrow("foo"))
     }
 }

--- a/Mokka/Tests/FunctionMock/ReturningFunctionMockTests.swift
+++ b/Mokka/Tests/FunctionMock/ReturningFunctionMockTests.swift
@@ -228,4 +228,10 @@ class ReturningFunctionMockTests: XCTestCase {
         sut.defaultReturnValue = 0
         XCTAssertEqual(sut.recordCallAndReturn("foo"), 0)
     }
+    
+    func testResetSetsErrorToNil() {
+        sut.throws(TestError.errorOne)
+        sut.reset()
+        XCTAssertNoThrow(try sut.recordCallAndReturnOrThrow("foo"))
+    }
 }

--- a/Mokka/Tests/FunctionMock/ReturningFunctionMockTests.swift
+++ b/Mokka/Tests/FunctionMock/ReturningFunctionMockTests.swift
@@ -142,6 +142,47 @@ class ReturningFunctionMockTests: XCTestCase {
         XCTAssertEqual(result, 42)
     }
 
+    // MARK: Throwing
+    
+    func testDoesNotThrowErrorIfNotExplicitlyConfigured() {
+        sut.returns(42)
+        XCTAssertNoThrow(try sut.recordCallAndReturnOrThrow("foo"))
+    }
+    
+    func testThrowsErrorAfterSettingError() {
+        sut.throws(TestError.errorOne)
+        XCTAssertThrowsError(try sut.recordCallAndReturnOrThrow("foo")) { error in
+            XCTAssert(error is TestError, "Unexpected error type thrown")
+            XCTAssertEqual(error as! TestError, TestError.errorOne)
+        }
+    }
+    
+    func testRecordCallAndReturnOrThrowRecordsCallsWhenNotThrowing() {
+        sut.returns(42)
+        XCTAssertNoThrow(try sut.recordCallAndReturnOrThrow("foo"))
+        XCTAssertNoThrow(try sut.recordCallAndReturnOrThrow("bar"))
+        XCTAssertEqual(sut.callCount, 2)
+    }
+    
+    func testRecordCallAndReturnOrThrowCapturesArgumentsWhenNotThrowing() {
+        sut.returns(42)
+        XCTAssertNoThrow(try sut.recordCallAndReturnOrThrow("foo"))
+        XCTAssertEqual(sut.argument, "foo")
+    }
+
+    func testRecordCallAndReturnOrThrowRecordsCallsWhenThrowing() {
+        sut.throws(TestError.errorOne)
+        XCTAssertThrowsError(try sut.recordCallAndReturnOrThrow("foo"))
+        XCTAssertThrowsError(try sut.recordCallAndReturnOrThrow("bar"))
+        XCTAssertEqual(sut.callCount, 2)
+    }
+    
+    func testRecordCallAndReturnOrThrowCapturesArgumentsWhenThrowing() {
+        sut.throws(TestError.errorOne)
+        XCTAssertThrowsError(try sut.recordCallAndReturnOrThrow("foo"))
+        XCTAssertEqual(sut.argument, "foo")
+    }
+
     // MARK: Reset
     
     func testCallCountIsZeroAfterReset() {

--- a/MokkaExample/MokkaExample/UnderTest/Car.swift
+++ b/MokkaExample/MokkaExample/UnderTest/Car.swift
@@ -17,8 +17,14 @@ class Car {
         self.battery = battery
     }
     
-    func turnOn() {
-        engine.turnOn()
+    @discardableResult
+    func turnOn() -> Bool {
+        do {
+            try engine.turnOn()
+            return true
+        } catch {
+            return false
+        }
     }
     
     func setRadioVolume(to volume: Float) {

--- a/MokkaExample/MokkaExample/UnderTest/Engine.swift
+++ b/MokkaExample/MokkaExample/UnderTest/Engine.swift
@@ -8,8 +8,12 @@
 
 import Foundation
 
+enum EngineError: Error {
+    case outOfGas
+}
+
 protocol Engine {
-    func turnOn()
+    func turnOn() throws
     func turnOff()
     var isOn: Bool { get }
     

--- a/MokkaExample/MokkaExampleTests/Mocks/EngineMock.swift
+++ b/MokkaExample/MokkaExampleTests/Mocks/EngineMock.swift
@@ -12,8 +12,8 @@ import Mokka
 
 class EngineMock: Engine {
     let turnOnFunc = FunctionMock<Void>(name: "turnOn()")
-    func turnOn() {
-        turnOnFunc.recordCall()
+    func turnOn() throws {
+        try turnOnFunc.recordCallAndThrow()
     }
     
     let turnOffFunc = FunctionMock<Void>(name: "turnOff()")

--- a/MokkaExample/MokkaExampleTests/Tests/CarTests.swift
+++ b/MokkaExample/MokkaExampleTests/Tests/CarTests.swift
@@ -24,8 +24,20 @@ class CarTests: XCTestCase {
     // MARK: - Starting the car
     
     func testTurningOnTheCarTurnsOnTheEngine() {
-        car.turnOn()
+        let result = car.turnOn()
+
         XCTAssertTrue(engineMock.turnOnFunc.called)
+        XCTAssertEqual(result, true)
+    }
+    
+    func testTurnOnReturnsFalseIfTurningOnEngineFails() {
+        // make the engine mock throw an error in turnOn()
+        engineMock.turnOnFunc.throws(EngineError.outOfGas)
+        
+        let result = car.turnOn()
+        
+        XCTAssertTrue(engineMock.turnOnFunc.called)
+        XCTAssertEqual(result, false)
     }
     
     // MARK: - Acceleration


### PR DESCRIPTION
See #2.

- [x] Support in `FunctionMock`
- [x] Support in `ReturningFunctionMock`
- [x] Extend example
- [x] Extend documentation